### PR TITLE
Update docs for scaling_mode field of Orthographic projection 

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -227,7 +227,7 @@ pub struct OrthographicProjection {
     pub viewport_origin: Vec2,
     /// How the projection will scale when the viewport is resized.
     ///
-    /// Defaults to `ScalingMode::WindowScale(1.0)`
+    /// Defaults to `ScalingMode::WindowSize(1.0)`
     pub scaling_mode: ScalingMode,
     /// Scales the projection in world units.
     ///


### PR DESCRIPTION
# Objective

This PR updates the name of the enum variant used in the docs for `OrthographicProjection`.

## Solution

- Change the outdated 'WindowScale` to `WindowSize`.
